### PR TITLE
Adds an AttributesObject to the context of each component and its sub-components, if any, rather than adding the attributes to the global context.

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -48,6 +48,48 @@ class TwigAdapter extends Fractal.Adapter {
             const render = Twig.Template.prototype.render;
             Twig.Template.prototype.render = function(context, params) {
 
+                let attributes = new AttributesObject();
+
+                function AttributesObject() {
+                    let self = this;
+                    this.classes = '';
+                    this.attr = [];
+        
+                    this.addClass = function(...str) {
+                        // console.log(str);
+                        self.classes = _.flatten(str).join(' ');
+        
+                        return self;
+                    };
+        
+                    this.removeClass = function(...str) {
+                        // todo implement
+                        // self.classes = str.join(' ');
+        
+                        return self;
+                    };
+        
+                    this.setAttribute = function(attribute, value) {
+                        let str = `${attribute}="${value}"`;
+        
+                        self.attr.push(str);
+                        self.attr = _.uniq(self.attr);
+        
+                        return self;
+                    };
+                }
+        
+                AttributesObject.prototype.toString = function toString() {
+                    let attrList = [
+                        this.classes ? `class="${this.classes}"` : '',
+                        this.attr ? this.attr.join(' ') : '',
+                    ];
+        
+                    return attrList.join(' ');
+                };
+
+                context['attributes'] = attributes;
+
                 if (!self._config.pristine && this.id) {
 
                     let handle = null;
@@ -177,50 +219,9 @@ class TwigAdapter extends Fractal.Adapter {
     }
 
     render(path, str, context, meta) {
-        let attributes = new AttributesObject();
         let self = this;
 
         meta = meta || {};
-
-        function AttributesObject() {
-            let self = this;
-            this.classes = '';
-            this.attr = [];
-
-            this.addClass = function(...str) {
-                // console.log(str);
-                self.classes = _.flatten(str).join(' ');
-
-                return self;
-            };
-
-            this.removeClass = function(...str) {
-                // todo implement
-                // self.classes = str.join(' ');
-
-                return self;
-            };
-
-            this.setAttribute = function(attribute, value) {
-                let str = `${attribute}="${value}"`;
-
-                self.attr.push(str);
-                self.attr = _.uniq(self.attr);
-
-                return self;
-            };
-        }
-
-        AttributesObject.prototype.toString = function toString() {
-            let attrList = [
-                this.classes ? `class="${this.classes}"` : '',
-                this.attr ? this.attr.join(' ') : '',
-            ];
-
-            return attrList.join(' ');
-        };
-
-
 
         if (!this._config.pristine) {
             setEnv('_self', meta.self, context);
@@ -229,7 +230,6 @@ class TwigAdapter extends Fractal.Adapter {
             setEnv('_config', this._app.config(), context);
             setEnv('title_prefix', '', context);
             setEnv('title_suffix', '', context);
-            setEnv('attributes', attributes, context);
         }
 
         return new Promise(function(resolve, reject){
@@ -244,7 +244,7 @@ class TwigAdapter extends Fractal.Adapter {
                     name: meta.self ? `${self._config.handlePrefix}${meta.self.handle}` : tplPath,
                     precompiled: str
                 });
-                resolve(template.render(context));
+                resolve(template.render(context, 'test'));
             } catch (e) {
                 reject(new Error(e));
             }

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -88,7 +88,9 @@ class TwigAdapter extends Fractal.Adapter {
                     return attrList.join(' ');
                 };
 
-                context['attributes'] = attributes;
+                if (!config.pristine) {
+                    context['attributes'] = attributes;
+                }
 
                 if (!self._config.pristine && this.id) {
 

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -244,7 +244,7 @@ class TwigAdapter extends Fractal.Adapter {
                     name: meta.self ? `${self._config.handlePrefix}${meta.self.handle}` : tplPath,
                     precompiled: str
                 });
-                resolve(template.render(context, 'test'));
+                resolve(template.render(context));
             } catch (e) {
                 reject(new Error(e));
             }


### PR DESCRIPTION
This fixes issue #5 
